### PR TITLE
fix: keep choices in sync with available nodes

### DIFF
--- a/branching_xblock/static/css/studio_editor.css
+++ b/branching_xblock/static/css/studio_editor.css
@@ -150,3 +150,15 @@
 .choice-row .btn-delete-choice:hover {
     opacity: 0.85;
 }
+
+/* Small informational notes with icon */
+.editor-note {
+    font-size: 0.75em;
+    color: #555;
+    margin-top: 0.25em;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.4em;
+    font-style: italic;
+}
+

--- a/branching_xblock/static/css/studio_editor.css
+++ b/branching_xblock/static/css/studio_editor.css
@@ -151,14 +151,9 @@
     opacity: 0.85;
 }
 
-/* Small informational notes with icon */
 .editor-note {
     font-size: 0.75em;
     color: #555;
     margin-top: 0.25em;
-    display: flex;
-    align-items: flex-start;
-    gap: 0.4em;
     font-style: italic;
 }
-

--- a/branching_xblock/static/handlebars/node-block.handlebars
+++ b/branching_xblock/static/handlebars/node-block.handlebars
@@ -3,7 +3,7 @@
     <span class="node-title">Node {{inc idx}}</span>
     <button type="button" class="btn-delete-node">Delete</button>
   </div>
-  <p>If you delete this node, please update any choice target nodes that pointed to this node.</p>
+  <p class="editor-note">If you delete this node, please update any choice target nodes that point to this node.</p>
   <label>Content:
     <textarea class="node-content">{{node.content}}</textarea>
   </label>
@@ -21,6 +21,6 @@
   </label>
   <div class="choices-container">
     <button type="button" class="btn-add-choice">Add Choice</button>
-    <p>Please note choices with blank node targets will be removed when saving.</p>
+    <p class="editor-note">Choices with blank node targets will be discarded.</p>
   </div>
 </div>

--- a/branching_xblock/static/handlebars/node-block.handlebars
+++ b/branching_xblock/static/handlebars/node-block.handlebars
@@ -3,6 +3,7 @@
     <span class="node-title">Node {{inc idx}}</span>
     <button type="button" class="btn-delete-node">Delete</button>
   </div>
+  <p>If you delete this node, please update any choice target nodes that pointed to this node.</p>
   <label>Content:
     <textarea class="node-content">{{node.content}}</textarea>
   </label>
@@ -20,5 +21,6 @@
   </label>
   <div class="choices-container">
     <button type="button" class="btn-add-choice">Add Choice</button>
+    <p>Please note choices with blank node targets will be removed when saving.</p>
   </div>
 </div>

--- a/branching_xblock/static/js/src/studio_editor.js
+++ b/branching_xblock/static/js/src/studio_editor.js
@@ -83,7 +83,8 @@ function BranchingStudioEditor(runtime, element, data) {
 
       let seenIds = [];
 
-      $(choice).find('option').each((_, option) => {
+      const selected = choice.selectedIndex;
+      $(choice).find('option').each((index, option) => {
         const $option = $(option);
         const val = $option.val();
         if (availableIds.includes(val)) {
@@ -92,6 +93,10 @@ function BranchingStudioEditor(runtime, element, data) {
         } else {
           // the node was deleted, so remove the option
           $option.remove();
+          // if the selected option was removed, unselect (otherwise another will be selected, which is confusing)
+          if (selected == index) {
+            choice.selectedIndex = -1;
+          }
         }
         seenIds.push(val);
       });


### PR DESCRIPTION
## Description

Previously, if a choice was added, then later nodes were added/removed, the available target node options for the choices would not be updated. This resulted in inability to select nodes,
or choices pointing to removed nodes.
This fixes that by updating all the choice select elements whenever a node is added or removed.
Also add help text to the delete node and add choice buttons to clarify behaviour when nodes are deleted.

<details>
<summary>screenshots</summary>

<img width="1186" height="191" alt="1755843864" src="https://github.com/user-attachments/assets/11b1c3ee-2d5a-4b84-a4dc-20406e876453" />


<img width="739" height="327" alt="1755843870" src="https://github.com/user-attachments/assets/5c9e210a-0f39-4678-9648-6b04d5b26e8e" />


</details>



Also fix bugs where .trim() can be called on undefined values. Fix them by defaulting to an empty string if the values are undefined.

## Supporting information

Private-ref: https://tasks.opencraft.com/browse/BB-9970

## Testing instructions

- create an instance of this xblock in studio
- edit the block
- add a single node (Node 1), write something in the content field, add a choice, write something in the choice text field
- note that there are no available options for the choice target (the dropdown will be empty)
- save the block
- verify that there are no errors raised, and that the choice with empty target is gone (it was invalid and was dropped)
- edit the block again
- add some choices, write something in the choice text fields. (the dropdowns will still be empty)
- add a node
- verify the dropdowns are populated with the new node (the new node is automatically selected)
- add another node
- verify the dropdowns are populated with the new node as well, also verify the selected node doesn't change
- delete a node
- verify that any choices that pointed to the deleted node now have an empty target (ie. no node is selected)
- experiment with various combinations of setting choice target nodes, and adding and removing nodes
- verify there are no errors, and the target node selections update as expected


## Deadline

None

