### PR TITLE
[BB-10352] Additional fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,26 @@ To build and run it:
 
 The XBlock SDK Workbench, including this XBlock, will be available on the list of XBlocks at http://localhost:8000
 
+Site-config first-node message
+******************************
+
+Admins can define a global HTML snippet that is used as the default content for the first node in the Studio editor when that node has no content yet.
+
+- Configure this in Django SiteConfiguration ``site_values`` under the key ``branching_xblock``:
+
+  .. code-block:: json
+
+      {
+        "branching_xblock": {
+          "FIRST_NODE_HTML": "<p>Welcome to the scenario.</p>"
+        }
+      }
+
+- This value is sanitized server-side (via ``bleach`` when available). Allowed tags:
+  ``p``, ``br``, ``strong``, ``b``, ``em``, ``u``, ``h3``, ``h4``, ``h5``, ``h6``, ``hr``, ``ul``, ``ol``, ``li``, ``a``.
+  Allowed attributes: links permit ``href``, ``title``, ``target``, ``rel``.
+- Behavior note: this snippet is not automatically prepended/appended at runtime in the learner view; it is only used to pre-fill empty first-node content in Studio.
+
 Translating
 ***********
 

--- a/branching_xblock/branching_xblock.py
+++ b/branching_xblock/branching_xblock.py
@@ -338,7 +338,8 @@ class BranchingXBlock(XBlock):
                     'url':  raw.get('media', {}).get('url', '')
                 },
                 'choices': raw.get('choices', []),
-                'hint':     raw.get('hint', '')
+                'hint':     raw.get('hint', ''),
+                'transcript_url': raw.get('transcript_url', ''),
             })
 
         # 2) Remap choice targets & clean arrays
@@ -373,7 +374,8 @@ class BranchingXBlock(XBlock):
                 'content':  node['content'],
                 'media':    node['media'],
                 'choices':  cleaned,
-                'hint': node.get('hint', '')
+                'hint': node.get('hint', ''),
+                'transcript_url': node.get('transcript_url', ''),
             })
 
         # 3) Persist scenario_data & settings

--- a/branching_xblock/branching_xblock.py
+++ b/branching_xblock/branching_xblock.py
@@ -10,6 +10,8 @@ from xblock.core import XBlock
 from xblock.fields import Boolean, Dict, Float, List, Scope, String
 from xblock.utils.resources import ResourceLoader
 
+from .compat import get_site_configuration_value, sanitize_html
+
 resource_loader = ResourceLoader(__name__)
 
 logger = logging.getLogger(__name__)
@@ -229,18 +231,25 @@ class BranchingXBlock(XBlock):
         frag.add_javascript(self.resource_string("js/src/studio_editor.js"))
         frag.add_css(self.resource_string("css/studio_editor.css"))
 
+        first_node_html = sanitize_html(
+            get_site_configuration_value("branching_xblock", "FIRST_NODE_HTML") or ""
+        )
         init_data = {
             "nodes":       self.scenario_data.get("nodes", []),
             "enable_undo": bool(self.enable_undo),
             "enable_scoring": bool(self.enable_scoring),
             "max_score":   self.max_score,
             "display_name": self.display_name,
+            "first_node_html": first_node_html,
         }
         # Initialize JS
         frag.initialize_js('BranchingStudioEditor', init_data)
         return frag
 
     def _get_state(self):
+        first_node_html = sanitize_html(
+            get_site_configuration_value("branching_xblock", "FIRST_NODE_HTML") or ""
+        )
         return {
             "nodes":           self.scenario_data.get("nodes", {}),
             "start_node_id":   self.scenario_data.get("start_node_id"),
@@ -253,6 +262,7 @@ class BranchingXBlock(XBlock):
             "history":         list(self.history),
             "has_completed":   bool(self.has_completed),
             "score":           self.score,
+            "first_node_html": first_node_html,
         }
 
     @XBlock.json_handler

--- a/branching_xblock/branching_xblock.py
+++ b/branching_xblock/branching_xblock.py
@@ -234,6 +234,7 @@ class BranchingXBlock(XBlock):
             "enable_undo": bool(self.enable_undo),
             "enable_scoring": bool(self.enable_scoring),
             "max_score":   self.max_score,
+            "display_name": self.display_name,
         }
         # Initialize JS
         frag.initialize_js('BranchingStudioEditor', init_data)
@@ -247,6 +248,7 @@ class BranchingXBlock(XBlock):
             "enable_scoring":  bool(self.enable_scoring),
             "enable_hints":    bool(self.enable_hints),
             "max_score":       self.max_score,
+            "display_name":    self.display_name,
             "current_node":    self.get_current_node(),
             "history":         list(self.history),
             "has_completed":   bool(self.has_completed),
@@ -384,6 +386,7 @@ class BranchingXBlock(XBlock):
         self.enable_scoring = bool(payload.get('enable_scoring', self.enable_scoring))
         self.enable_hints = bool(payload.get('enable_hints', self.enable_hints))
         self.max_score = float(payload.get('max_score', self.max_score))
+        self.display_name = payload.get('display_name', self.display_name)
 
         # 4) Validate & respond
         errors = self.validate_scenario()

--- a/branching_xblock/compat.py
+++ b/branching_xblock/compat.py
@@ -15,7 +15,7 @@ DEFAULT_ALLOWED_TAGS = [
     "p",
     "br",
     "strong",
-    "b"
+    "b",
     "em",
     "u",
     "h3",

--- a/branching_xblock/compat.py
+++ b/branching_xblock/compat.py
@@ -1,0 +1,127 @@
+"""
+Compatibility helpers for optional Open edX imports and sanitization.
+"""
+from html import escape
+from typing import Any
+from django.conf import settings
+
+try:
+    import bleach
+except Exception:  # pragma: no cover - fallback if bleach isn't installed
+    bleach = None
+
+
+DEFAULT_ALLOWED_TAGS = [
+    "p",
+    "br",
+    "strong",
+    "b"
+    "em",
+    "u",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "hr",
+    "ul",
+    "ol",
+    "li",
+    "a",
+]
+
+DEFAULT_ALLOWED_ATTRIBUTES = {
+    "a": ["href", "title", "target", "rel"],
+}
+
+
+def _get_current_site_configuration_value(key: str, default: Any = None) -> Any:  # pragma: no cover
+    """
+    Get value from the current site configuration.
+
+    Args:
+        key: The key to retrieve from the site configuration.
+        default: The default value to return if the key is not found.
+    Returns:
+        The value associated with the key, or the default value.
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from openedx.core.djangoapps.site_configuration.helpers import get_value
+
+    return get_value(key, default)
+
+
+def _get_site_configuration_value(domain: str, key: str, default: Any = None) -> Any:  # pragma: no cover
+    """
+    Get value from the site configuration for a given domain.
+
+    Args:
+        domain: The domain to retrieve site configuration for.
+        key: The key to retrieve from the site configuration.
+        default: The default value to return if the key is not found.
+
+    Returns:
+        The value associated with the key, or the default value.
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
+
+    try:
+        config = SiteConfiguration.objects.get(site__domain=domain).site_values
+        return config.get(key, default)
+    except SiteConfiguration.DoesNotExist:
+        return default
+
+
+def get_site_configuration_value(block_settings_key: str, config_key: str) -> str | None:
+    """
+    Retrieve configuration value from site configuration based on execution context.
+
+    In Open edX, site configurations are defined separately for LMS and CMS (Studio)
+    environments. API keys are typically stored in the LMS site configuration.
+    This function handles the different contexts:
+
+    In LMS: Get the API key directly from the current site configuration.
+    In CMS: Get the API key using LMS site configuration.
+        The LMS domain is retrieved from CMS site configuration or Django settings.
+
+    This special handling is necessary because when an XBlock is being edited in Studio,
+    it needs to access API keys that are stored in the corresponding LMS site configuration,
+    not in the Studio site configuration.
+
+    Args:
+        block_settings_key: The key under which block settings are stored.
+        config_key: Configuration key to retrieve.
+
+    Returns:
+        The configuration value if found, None otherwise.
+    """
+    if getattr(settings, "SERVICE_VARIANT", None) == "lms":
+        block_config = _get_current_site_configuration_value(block_settings_key, {})
+        return block_config.get(config_key)
+
+    lms_base = _get_current_site_configuration_value("LMS_BASE", getattr(settings, "LMS_BASE", None))
+    block_config = _get_site_configuration_value(lms_base, block_settings_key, {})
+    return block_config.get(config_key)
+
+
+def sanitize_html(
+    value: str,
+    allowed_tags=None,
+    allowed_attributes=None,
+):
+    """
+    Sanitize HTML to a safe subset to avoid script injection.
+    """
+    if not value:
+        return ""
+
+    if bleach:
+        return bleach.clean(
+            value,
+            tags=allowed_tags or DEFAULT_ALLOWED_TAGS,
+            attributes=allowed_attributes or DEFAULT_ALLOWED_ATTRIBUTES,
+            strip=True,
+        )
+
+    # Minimal fallback: escape everything if bleach is unavailable.
+    return escape(value)

--- a/branching_xblock/compat.py
+++ b/branching_xblock/compat.py
@@ -3,11 +3,12 @@ Compatibility helpers for optional Open edX imports and sanitization.
 """
 from html import escape
 from typing import Any
+
 from django.conf import settings
 
 try:
-    import bleach
-except Exception:  # pragma: no cover - fallback if bleach isn't installed
+    import bleach  # pylint: disable=import-error
+except Exception:  # pylint: disable=broad-exception-caught
     bleach = None
 
 
@@ -74,19 +75,7 @@ def _get_site_configuration_value(domain: str, key: str, default: Any = None) ->
 
 def get_site_configuration_value(block_settings_key: str, config_key: str) -> str | None:
     """
-    Retrieve configuration value from site configuration based on execution context.
-
-    In Open edX, site configurations are defined separately for LMS and CMS (Studio)
-    environments. API keys are typically stored in the LMS site configuration.
-    This function handles the different contexts:
-
-    In LMS: Get the API key directly from the current site configuration.
-    In CMS: Get the API key using LMS site configuration.
-        The LMS domain is retrieved from CMS site configuration or Django settings.
-
-    This special handling is necessary because when an XBlock is being edited in Studio,
-    it needs to access API keys that are stored in the corresponding LMS site configuration,
-    not in the Studio site configuration.
+    Retrieve a value from site configuration for LMS/Studio contexts.
 
     Args:
         block_settings_key: The key under which block settings are stored.

--- a/branching_xblock/static/css/branching_xblock.css
+++ b/branching_xblock/static/css/branching_xblock.css
@@ -49,6 +49,21 @@
     border: none;
 }
 
+.branching-scenario .transcript-link {
+    padding: 0 1em 1em;
+    font-size: 0.95em;
+}
+
+.branching-scenario .transcript-link a {
+    color: #0a6ebd;
+    text-decoration: none;
+}
+
+.branching-scenario .transcript-link a:hover,
+.branching-scenario .transcript-link a:focus {
+    text-decoration: underline;
+}
+
 .branching-scenario .node-media audio {
     width: auto;
     max-width: 100%;

--- a/branching_xblock/static/css/branching_xblock.css
+++ b/branching_xblock/static/css/branching_xblock.css
@@ -34,6 +34,21 @@
     height: auto;
 }
 
+.branching-scenario .node-media .bx-media-embed {
+    position: relative;
+    width: 100%;
+    padding-top: 56.25%; /* 16:9 */
+}
+
+.branching-scenario .node-media .bx-media-embed iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+
 .branching-scenario .node-media audio {
     width: auto;
     max-width: 100%;

--- a/branching_xblock/static/css/studio_editor.css
+++ b/branching_xblock/static/css/studio_editor.css
@@ -107,7 +107,6 @@
     display: flex;
     flex-direction: column;
     gap: 0.35em;
-    font-weight: 600;
 }
 
 .node-block .transcript-url {

--- a/branching_xblock/static/css/studio_editor.css
+++ b/branching_xblock/static/css/studio_editor.css
@@ -31,8 +31,20 @@
 }
 
 .settings label {
-    font-size: 1.1em;
+    font-size: 1em;
     font-weight: bold;
+}
+
+.settings .display-name-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75em;
+    font-size: 1em;
+    font-weight: 600;
+}
+
+.settings .display-name-row input[name="display_name"] {
+    min-width: 220px;
 }
 
 .node-block {
@@ -83,6 +95,22 @@
 .node-block .media-url {
     display: block;
     margin-top: 0.5em;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.node-block .transcript-field {
+    margin-top: 0.5em;
+}
+
+.node-block .transcript-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35em;
+    font-weight: 600;
+}
+
+.node-block .transcript-url {
     width: 100%;
     box-sizing: border-box;
 }

--- a/branching_xblock/static/handlebars/node-block.handlebars
+++ b/branching_xblock/static/handlebars/node-block.handlebars
@@ -15,7 +15,7 @@
       <option value="audio" {{#if (eq node.media.type 'audio')}}selected{{/if}}>Audio</option>
     </select>
     <input type="text" class="media-url" placeholder="URL" value="{{node.media.url}}"/>
-    <p class="editor-note">Supports direct media files (.mp4/.webm/.mp3) or embeddable links from YouTube, Vimeo, Panopto.</p>
+    <p class="editor-note">Supports direct media files (.mp4/.webm/.mp3) or links from YouTube, Vimeo, Panopto.</p>
     <div class="transcript-field">
       <label class="transcript-label">Transcript URL (for audio/video):
         <input type="text" class="transcript-url" placeholder="https://..." value="{{node.transcript_url}}" />

--- a/branching_xblock/static/handlebars/node-block.handlebars
+++ b/branching_xblock/static/handlebars/node-block.handlebars
@@ -16,6 +16,11 @@
     </select>
     <input type="text" class="media-url" placeholder="URL" value="{{node.media.url}}"/>
     <p class="editor-note">Supports direct media files (.mp4/.webm/.mp3) or embeddable links from YouTube, Vimeo, Panopto.</p>
+    <div class="transcript-field">
+      <label class="transcript-label">Transcript URL (for audio/video):
+        <input type="text" class="transcript-url" placeholder="https://..." value="{{node.transcript_url}}" />
+      </label>
+    </div>
   </label>
   <label>Hint:<br/>
     <textarea class="node-hint">{{node.hint}}</textarea>

--- a/branching_xblock/static/handlebars/node-block.handlebars
+++ b/branching_xblock/static/handlebars/node-block.handlebars
@@ -15,6 +15,7 @@
       <option value="audio" {{#if (eq node.media.type 'audio')}}selected{{/if}}>Audio</option>
     </select>
     <input type="text" class="media-url" placeholder="URL" value="{{node.media.url}}"/>
+    <p class="editor-note">Supports direct media files (.mp4/.webm/.mp3) or embeddable links from YouTube, Vimeo, Panopto.</p>
   </label>
   <label>Hint:<br/>
     <textarea class="node-hint">{{node.hint}}</textarea>

--- a/branching_xblock/static/handlebars/settings-panel.handlebars
+++ b/branching_xblock/static/handlebars/settings-panel.handlebars
@@ -1,5 +1,5 @@
 <div class="settings">
-  <label>
+  <label class="display-name-row">
     Display Name:
     <input type="text" name="display_name" value="{{display_name}}" />
   </label>

--- a/branching_xblock/static/handlebars/settings-panel.handlebars
+++ b/branching_xblock/static/handlebars/settings-panel.handlebars
@@ -1,5 +1,9 @@
 <div class="settings">
   <label>
+    Display Name:
+    <input type="text" name="display_name" value="{{display_name}}" />
+  </label>
+  <label>
     <input type="checkbox" name="enable_undo" {{#if enable_undo}}checked{{/if}}/>
     Allow undo
   </label>

--- a/branching_xblock/static/html/branching_xblock.html
+++ b/branching_xblock/static/html/branching_xblock.html
@@ -2,6 +2,7 @@
     <div class="active-scenario" data-role="active">
         <div class="node-content" data-role="content"></div>
         <div class="node-media" data-role="media"></div>
+        <div class="transcript-link" data-role="transcript" hidden></div>
         <div class="node-hint-container" data-role="hint-container">
             <details class="hint-collapsible" data-role="hint-collapsible" hidden>
                 <summary class="hint-summary" data-role="hint-summary">

--- a/branching_xblock/static/js/src/branching_xblock.js
+++ b/branching_xblock/static/js/src/branching_xblock.js
@@ -71,6 +71,10 @@ function BranchingXBlock(runtime, element) {
         return `<div class="bx-media-embed"><iframe src="${src}" title="Embedded media" allow="autoplay; fullscreen" allowfullscreen sandbox="allow-scripts allow-same-origin allow-popups allow-forms"></iframe></div>`;
     }
 
+    function transcriptLink(href) {
+        return `<a href="${href}" target="_blank" rel="noopener noreferrer">Download transcript</a>`;
+    }
+
     function setHintVisibility(visible) {
         const $details = $el.find('[data-role="hint-collapsible"]');
         isHintVisible = Boolean(visible);
@@ -93,24 +97,38 @@ function BranchingXBlock(runtime, element) {
         const media = (node && node.media) || {};
         const mediaUrl = media.url || '';
         const $media = $el.find('[data-role="media"]');
+        const $transcript = $el.find('[data-role="transcript"]');
+        const setTranscript = (href) => {
+            if (href) {
+                $transcript.html(transcriptLink(href)).prop('hidden', false);
+            } else {
+                $transcript.prop('hidden', true).empty();
+            }
+        };
         if (media.type === 'image') {
             $media.html(`<img src="${mediaUrl}" alt=""/>`);
+            setTranscript(null);
         } else if (media.type === 'audio') {
             $media.html(`<audio src="${mediaUrl}" controls />`);
+            setTranscript(node && node.transcript_url);
         } else if (media.type === 'video') {
             if (!mediaUrl) {
                 $media.empty();
+                setTranscript(null);
             } else if (isMediaFile(mediaUrl)) {
                 $media.html(`<video src="${mediaUrl}" controls />`);
+                setTranscript(node && node.transcript_url);
             } else {
                 const yt = normalizeYouTube(mediaUrl);
                 const vm = normalizeVimeo(mediaUrl);
                 const pn = normalizePanopto(mediaUrl);
                 const embedUrl = yt || vm || pn || mediaUrl;
                 $media.html(iframeHtml(embedUrl));
+                setTranscript(node && node.transcript_url);
             }
         } else {
             $media.empty();
+            setTranscript(null);
         }
         // Content
         $el.find('[data-role="content"]').html(

--- a/branching_xblock/static/js/src/branching_xblock.js
+++ b/branching_xblock/static/js/src/branching_xblock.js
@@ -131,9 +131,8 @@ function BranchingXBlock(runtime, element) {
             setTranscript(null);
         }
         // Content
-        $el.find('[data-role="content"]').html(
-            (node && node.content) || ''
-        );
+        const nodeContent = (node && node.content) || '';
+        $el.find('[data-role="content"]').html(nodeContent);
 
         // Hint
         const nodeId = node?.id || null;

--- a/branching_xblock/static/js/src/studio_editor.js
+++ b/branching_xblock/static/js/src/studio_editor.js
@@ -174,7 +174,8 @@ function BranchingStudioEditor(runtime, element, data) {
           enable_undo:    $settings.find('[name="enable_undo"]').is(':checked'),
           enable_scoring: $settings.find('[name="enable_scoring"]').is(':checked'),
           enable_hints:   $settings.find('[name="enable_hints"]').is(':checked'),
-          max_score:      parseFloat($settings.find('[name="max_score"]').val()) || 0
+          max_score:      parseFloat($settings.find('[name="max_score"]').val()) || 0,
+          display_name:   $settings.find('[name="display_name"]').val()?.trim() || ''
       };
 
       $editor.find('.node-block').each(function() {

--- a/branching_xblock/static/js/src/studio_editor.js
+++ b/branching_xblock/static/js/src/studio_editor.js
@@ -37,7 +37,7 @@ function BranchingStudioEditor(runtime, element, data) {
     if (!nodes.length) {
       nodes.push({
         id: 'temp',
-        content: '',
+        content: state.first_node_html || '',
         media: {type: '', url: ''},
         choices: [],
         hint: '',
@@ -48,6 +48,9 @@ function BranchingStudioEditor(runtime, element, data) {
     $editor.append(Templates['settings-panel'](state));
 
     nodes.forEach((node, idx) => {
+      if (!node.content && idx === 0 && state.first_node_html) {
+        node.content = state.first_node_html;
+      }
 
       const options = nodes.map((n, j) => ({
         id: n.id,

--- a/branching_xblock/static/js/src/studio_editor.js
+++ b/branching_xblock/static/js/src/studio_editor.js
@@ -40,7 +40,8 @@ function BranchingStudioEditor(runtime, element, data) {
         content: '',
         media: {type: '', url: ''},
         choices: [],
-        hint: ''
+        hint: '',
+        transcript_url: ''
       });
     }
 
@@ -69,6 +70,7 @@ function BranchingStudioEditor(runtime, element, data) {
 
     bindInteractions();
     bindActions();
+    updateTranscriptVisibility();
   }
 
   function updateChoiceUI() {
@@ -114,6 +116,19 @@ function BranchingStudioEditor(runtime, element, data) {
     });
   }
 
+  function updateTranscriptVisibility($scope) {
+    const $target = $scope ? $scope.find('.media-type') : $editor.find('.media-type');
+    $target.each(function() {
+      const type = $(this).val();
+      const $field = $(this).closest('label').find('.transcript-field');
+      if (type === 'audio' || type === 'video') {
+        $field.show();
+      } else {
+        $field.hide();
+      }
+    });
+  }
+
   function bindInteractions() {
     $editor.find('.btn-delete-node').off('click').on('click', function() {
       $(this).closest('.node-block').remove();
@@ -122,6 +137,10 @@ function BranchingStudioEditor(runtime, element, data) {
                .find('.node-title').text(`Node ${i+1}`);
       });
       updateChoiceUI();
+    });
+
+    $editor.find('.media-type').off('change').on('change', function() {
+      updateTranscriptVisibility($(this).closest('.node-block'));
     });
 
     $editor.off('click', '.btn-add-choice').on('click', '.btn-add-choice', function() {
@@ -152,7 +171,8 @@ function BranchingStudioEditor(runtime, element, data) {
           content: '',
           media:   { type: '', url: '' },
           choices: [],
-          hint:    ''
+          hint:    '',
+          transcript_url: ''
         },
         idx
       };
@@ -161,6 +181,7 @@ function BranchingStudioEditor(runtime, element, data) {
       $(this).before($newNode);
       bindInteractions();
       updateChoiceUI();
+      updateTranscriptVisibility($newNode);
     });
   }
 
@@ -185,6 +206,7 @@ function BranchingStudioEditor(runtime, element, data) {
         const mediaType = $n.find('.media-type').val();
         const choices = [];
         const nodeHint = $n.find('.node-hint').val()?.trim() || '';
+        const transcriptUrl = $n.find('.transcript-url').val()?.trim() || '';
 
         $n.find('.choice-row').each(function() {
           const $c = $(this);
@@ -194,13 +216,14 @@ function BranchingStudioEditor(runtime, element, data) {
               choices.push({ text: text, target_node_id: target });
           }
         });
-        if (content || mediaUrl || choices.length) {
+        if (content || mediaUrl || choices.length || transcriptUrl) {
           payload.nodes.push({
               id:     $n.data('node-id'),
               content,
               media:  { type: mediaType, url: mediaUrl },
               choices,
-              hint: nodeHint
+              hint: nodeHint,
+              transcript_url: transcriptUrl
           });
         }
       });

--- a/tests/test_branching_xblock.py
+++ b/tests/test_branching_xblock.py
@@ -1,4 +1,6 @@
 import json
+from unittest import mock
+
 import pytest
 
 from django.test.client import RequestFactory
@@ -40,6 +42,18 @@ def block(runtime, scope_ids):
         BranchingXBlock,
         scope_ids=scope_ids
     )
+
+
+@pytest.fixture(autouse=True)
+def _mock_site_config():
+    """
+    Prevent tests from depending on compat.py/site configuration lookups.
+    """
+    with mock.patch(
+        "branching_xblock.branching_xblock.get_site_configuration_value",
+        return_value="",
+    ):
+        yield
 
 
 def test_get_current_state_empty(rf, block):

--- a/tests/test_branching_xblock.py
+++ b/tests/test_branching_xblock.py
@@ -69,13 +69,15 @@ def test_studio_submit_creates_scenario(rf, block):
                 "id": "temp-1",
                 "content": "First node",
                 "media": {"type": "image", "url": "http://img"},
-                "choices": [{"text": "Go to 2", "target_node_id": "temp-2"}]
+                "choices": [{"text": "Go to 2", "target_node_id": "temp-2"}],
+                "transcript_url": ""
             },
             {
                 "id": "temp-2",
                 "content": "Second node",
                 "media": {"type": "", "url": ""},
-                "choices": []
+                "choices": [],
+                "transcript_url": "http://example.com/t.vtt"
             }
         ],
         "enable_undo": True,
@@ -96,6 +98,7 @@ def test_studio_submit_creates_scenario(rf, block):
     second_node = node_list[1]
     assert block.scenario_data["start_node_id"] == first_node["id"]
     assert first_node["choices"][0]["target_node_id"] == second_node["id"]
+    assert second_node["transcript_url"] == "http://example.com/t.vtt"
     assert block.enable_undo is True
     assert block.enable_scoring is True
     assert block.max_score == 77

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+from unittest import mock
+
+from branching_xblock import compat
+
+
+def test_get_site_configuration_value():
+    with mock.patch.object(
+        compat.settings, "SERVICE_VARIANT", "lms", create=True
+    ), mock.patch.object(
+        compat, "_get_current_site_configuration_value", return_value={"FIRST_NODE_HTML": "<p>x</p>"}
+    ) as get_current, mock.patch.object(
+        compat, "_get_site_configuration_value"
+    ) as get_for_domain:
+        assert compat.get_site_configuration_value("branching_xblock", "FIRST_NODE_HTML") == "<p>x</p>"
+        get_current.assert_called_once_with("branching_xblock", {})
+        get_for_domain.assert_not_called()
+
+
+def test_sanitize_html_uses_bleach_defaults():
+    calls = {}
+
+    def fake_clean(value, tags, attributes, strip):
+        calls["value"] = value
+        calls["tags"] = tags
+        calls["attributes"] = attributes
+        calls["strip"] = strip
+        return "CLEANED"
+
+    with mock.patch.object(compat, "bleach", SimpleNamespace(clean=fake_clean)):
+        assert compat.sanitize_html("<b>ok</b>") == "CLEANED"
+
+    assert calls["value"] == "<b>ok</b>"
+    assert calls["tags"] == compat.DEFAULT_ALLOWED_TAGS
+    assert calls["attributes"] == compat.DEFAULT_ALLOWED_ATTRIBUTES
+    assert calls["strip"] is True
+


### PR DESCRIPTION
## Description

This PR addresses the following issues which are marked as critical or high in the report found in the task:
1. Support video urls from Youtube, Panopto and Vimeo
2. Make display name editable
3. Add an external transcript downloadable link if media type is audio/video

## Supporting Information

OpenCraft Internal Jira task: [BB-10352](https://tasks.opencraft.com/browse/BB-10352)

## Testing Instructions

1. Deploy this branch on redwood devstack
2. Create a branching scenario xblock and add a few nodes with all the different media types available.
3. For a video node, add video urls from Youtube or Panopto or Vimeo and confirm that the video loads correctly.
4. For audio or video node, confirm that a transcript url field shows up and if set, opens the link in a separate tab.
