### PR TITLE
[BB-10352] Move node html to help section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,10 +74,10 @@ To build and run it:
 
 The XBlock SDK Workbench, including this XBlock, will be available on the list of XBlocks at http://localhost:8000
 
-Site-config first-node message
-******************************
+Site-config authoring help
+**************************
 
-Admins can define a global HTML snippet that is used as the default content for the first node in the Studio editor when that node has no content yet.
+Admins can optionally provide a help/instructions HTML snippet shown to authors in the Studio editor (as a collapsible help block in the settings panel).
 
 - Configure this in Django SiteConfiguration ``site_values`` under the key ``branching_xblock``:
 
@@ -85,14 +85,13 @@ Admins can define a global HTML snippet that is used as the default content for 
 
       {
         "branching_xblock": {
-          "FIRST_NODE_HTML": "<p>Welcome to the scenario.</p>"
+          "AUTHORING_HELP_HTML": "<p>You can use basic HTML in node content…</p>"
         }
       }
 
 - This value is sanitized server-side (via ``bleach`` when available). Allowed tags:
-  ``p``, ``br``, ``strong``, ``b``, ``em``, ``u``, ``h3``, ``h4``, ``h5``, ``h6``, ``hr``, ``ul``, ``ol``, ``li``, ``a``.
+  ``p``, ``br``, ``strong``, ``b``, ``em``, ``u``, ``code``, ``h3``, ``h4``, ``h5``, ``h6``, ``hr``, ``ul``, ``ol``, ``li``, ``a``.
   Allowed attributes: links permit ``href``, ``title``, ``target``, ``rel``.
-- Behavior note: this snippet is not automatically prepended/appended at runtime in the learner view; it is only used to pre-fill empty first-node content in Studio.
 
 Translating
 ***********

--- a/branching_xblock/compat.py
+++ b/branching_xblock/compat.py
@@ -19,6 +19,7 @@ DEFAULT_ALLOWED_TAGS = [
     "b",
     "em",
     "u",
+    "code",
     "h3",
     "h4",
     "h5",

--- a/branching_xblock/static/css/studio_editor.css
+++ b/branching_xblock/static/css/studio_editor.css
@@ -47,6 +47,52 @@
     min-width: 220px;
 }
 
+.bx-authoring-help {
+    border: 1px solid #d0d0d0;
+    border-radius: 4px;
+    background: #f8f9fa;
+    padding: 0.5em 0.75em;
+}
+
+.bx-authoring-help summary {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    font-weight: 600;
+    cursor: pointer;
+    user-select: none;
+    padding: 0.25em 0;
+}
+
+.bx-authoring-help summary::-webkit-details-marker {
+    display: none;
+}
+
+.bx-authoring-help summary::after {
+    content: "▾";
+    margin-left: auto;
+    transform: rotate(-90deg);
+    transition: transform 150ms ease-in-out;
+}
+
+.bx-authoring-help[open] summary::after {
+    transform: rotate(0deg);
+}
+
+.bx-authoring-help summary:hover {
+    color: #1d4ed8;
+}
+
+.bx-authoring-help summary:focus-visible {
+    outline: 2px solid #1d4ed8;
+    outline-offset: 2px;
+}
+
+.bx-authoring-help-body {
+    margin-top: 0.5em;
+    font-style: normal;
+}
+
 .node-block {
     max-width: 800px;
     background: #f9f9f9;

--- a/branching_xblock/static/css/studio_editor.css
+++ b/branching_xblock/static/css/studio_editor.css
@@ -51,7 +51,11 @@
     border: 1px solid #d0d0d0;
     border-radius: 4px;
     background: #f8f9fa;
-    padding: 0.5em 0.75em;
+    padding: 1em;
+    align-self: flex-start;
+    width: 100%;
+    max-width: 800px;
+    box-sizing: content-box;
 }
 
 .bx-authoring-help summary {
@@ -62,6 +66,7 @@
     cursor: pointer;
     user-select: none;
     padding: 0.25em 0;
+    color: #1d4ed8;
 }
 
 .bx-authoring-help summary::-webkit-details-marker {
@@ -71,12 +76,12 @@
 .bx-authoring-help summary::after {
     content: "▾";
     margin-left: auto;
-    transform: rotate(-90deg);
+    transform: rotate(0deg);
     transition: transform 150ms ease-in-out;
 }
 
 .bx-authoring-help[open] summary::after {
-    transform: rotate(0deg);
+    transform: rotate(180deg);
 }
 
 .bx-authoring-help summary:hover {

--- a/branching_xblock/static/handlebars/settings-panel.handlebars
+++ b/branching_xblock/static/handlebars/settings-panel.handlebars
@@ -19,4 +19,10 @@
     Max Score:
     <input type="number" name="max_score" value="{{max_score}}"/>
   </label>
+  {{#if authoring_help_html}}
+    <details class="bx-authoring-help">
+      <summary>Content authoring guidelines</summary>
+      <div class="editor-note bx-authoring-help-body">{{{authoring_help_html}}}</div>
+    </details>
+  {{/if}}
 </div>

--- a/branching_xblock/static/js/src/studio_editor.js
+++ b/branching_xblock/static/js/src/studio_editor.js
@@ -19,16 +19,6 @@ function BranchingStudioEditor(runtime, element, data) {
     return `temp-${i}`;
   };
 
-  function loadState() {
-      return $.ajax({
-        type: 'POST',
-        url: runtime.handlerUrl(element, 'get_current_state'),
-        data: '{}',
-        contentType: 'application/json; charset=utf-8',
-        dataType: 'json'
-      });
-  }
-
   function render(state) {
     $editor.empty();
     $errors.empty();
@@ -36,8 +26,8 @@ function BranchingStudioEditor(runtime, element, data) {
     const nodes = Object.values(state.nodes || {});
     if (!nodes.length) {
       nodes.push({
-        id: 'temp',
-        content: state.first_node_html || '',
+        id: uniqueId(),
+        content: '',
         media: {type: '', url: ''},
         choices: [],
         hint: '',
@@ -48,10 +38,6 @@ function BranchingStudioEditor(runtime, element, data) {
     $editor.append(Templates['settings-panel'](state));
 
     nodes.forEach((node, idx) => {
-      if (!node.content && idx === 0 && state.first_node_html) {
-        node.content = state.first_node_html;
-      }
-
       const options = nodes.map((n, j) => ({
         id: n.id,
         label: `Node ${j+1}`
@@ -82,7 +68,7 @@ function BranchingStudioEditor(runtime, element, data) {
         options[$(nb).data('node-id')] = `Node ${j+1}`;
       });
 
-    $('.choice-target').each((_, choice) => {
+    $editor.find('.choice-target').each((_, choice) => {
       const currentNodeId = $(choice).closest('.node-block').data('node-id');
       const availableIds = Object.keys(options).filter(opt => opt !== currentNodeId);
 
@@ -107,7 +93,7 @@ function BranchingStudioEditor(runtime, element, data) {
       });
 
       // add any new nodes
-      for (nodeId of availableIds) {
+      for (const nodeId of availableIds) {
         if (!seenIds.includes(nodeId)) {
           const $option = $('<option>');
           $option.val(nodeId);
@@ -257,5 +243,5 @@ function BranchingStudioEditor(runtime, element, data) {
     });
   }
 
-  loadState().then(render);
+  render(data || {});
 }

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -8,11 +8,11 @@ def test_get_site_configuration_value():
     with mock.patch.object(
         compat.settings, "SERVICE_VARIANT", "lms", create=True
     ), mock.patch.object(
-        compat, "_get_current_site_configuration_value", return_value={"FIRST_NODE_HTML": "<p>x</p>"}
+        compat, "_get_current_site_configuration_value", return_value={"AUTHORING_HELP_HTML": "<p>x</p>"}
     ) as get_current, mock.patch.object(
         compat, "_get_site_configuration_value"
     ) as get_for_domain:
-        assert compat.get_site_configuration_value("branching_xblock", "FIRST_NODE_HTML") == "<p>x</p>"
+        assert compat.get_site_configuration_value("branching_xblock", "AUTHORING_HELP_HTML") == "<p>x</p>"
         get_current.assert_called_once_with("branching_xblock", {})
         get_for_domain.assert_not_called()
 
@@ -34,4 +34,3 @@ def test_sanitize_html_uses_bleach_defaults():
     assert calls["tags"] == compat.DEFAULT_ALLOWED_TAGS
     assert calls["attributes"] == compat.DEFAULT_ALLOWED_ATTRIBUTES
     assert calls["strip"] is True
-


### PR DESCRIPTION
## Description

This PR moves the first node html into a authoring help section inside the XBlock editor based on the requirements in BB-10352.

## Supporting Information

OpenCraft Internal Jira task: [BB-10352](https://tasks.opencraft.com/browse/BB-10352)


## Screenshots

Collapsed section

<img width="995" height="213" alt="Screenshot 2026-01-12 at 11 32 43 AM" src="https://github.com/user-attachments/assets/4d74a3de-e931-44b0-a401-9c5ded75324b" />


Expanded section

<img width="914" height="352" alt="Screenshot 2026-01-12 at 11 33 00 AM" src="https://github.com/user-attachments/assets/a37286c9-a1c3-4bad-b1ab-e0d571ec5b9a" />


## Testing Instruction

1. Deploy this branch of the XBlock.
2. Go to site config and add the following config settings:
```
{
        "branching_xblock": {
          "AUTHORING_HELP_HTML": "<p>You can use basic HTML in node content…</p>"
        }
 }
 ```
 3. Add a new XBlock component and open the editor.
 4. Verify that the `content authoring guideline` collapsible section shows up and contains the html you set in the site config.
 5. Confirm that this html only shows up in the xblock editor and not as the node content.