### PR TITLE
feat: Add the ability to integrate with student notes

### DIFF
--- a/branching_xblock/branching_xblock.py
+++ b/branching_xblock/branching_xblock.py
@@ -9,11 +9,19 @@ from xblock.core import XBlock
 from xblock.fields import Boolean, Dict, Float, List, Scope, String
 from xblock.utils.resources import ResourceLoader
 
+try:
+    from xmodule.edxnotes_utils import edxnotes
+except ModuleNotFoundError:
+    def edxnotes(func):  # noqa: D103
+        return func
+
 from .compat import get_site_configuration_value, sanitize_html
 
 resource_loader = ResourceLoader(__name__)
 
 
+@XBlock.needs("user")
+@edxnotes
 class BranchingXBlock(XBlock):
     """
     Branching Scenario XBlock.
@@ -171,12 +179,19 @@ class BranchingXBlock(XBlock):
         path = os.path.join('static', path)
         return resource_loader.load_unicode(path)
 
+    def get_html(self):
+        """
+        Retrive the HTML from the static file.
+
+        This is required for the edxnotes decorator to inject the HTML.
+        """
+        return self.resource_string("html/branching_xblock.html")
+
     def student_view(self, context=None):
         """
         Create primary view of the BranchingXBlock, shown to students when viewing courses.
         """
-        html = self.resource_string("html/branching_xblock.html")
-        frag = Fragment(html)
+        frag = Fragment(self.get_html())
         frag.add_css(self.resource_string("css/branching_xblock.css"))
         frag.add_javascript(self.resource_string("js/src/branching_xblock.js"))
         frag.initialize_js('BranchingXBlock')


### PR DESCRIPTION
## Description

Adds the ability to make student notes and activate it on branching xblock.

## Testing instructions

- Enable `notes` plugin in tutor and install it, if it's not available
- `tutor plugin install notes`
- `tutor plugin enable notes`
- Make sure that branching XBlock is mounted in devstack
- Check `tutor mounts list` and see if XBlock is mounted 
- If the XBlock is not mounted you can switch to the repository `cd bracnhing-xblock` and `tutor mounts add .`
- Build Images `tutor image build openedx-dev`
- `tutor image build notes`
- Once the Branching XBlock is installed, enable it in the advance settings and use it in a course
-  Check if you are able to make student notes
- Now change the branch in Branching XBlock to `farhaan/edx-notes-integration`
- Restart lms and cms `tutor dev restart lms cms`
- Now try again to make notes
- Student notes should be available

:Note: 

If notes is not working in HTML XBlock as well we need to set `USE_EXTRACTED_HTML_BLOCK` in [common/settings](https://github.com/openedx/openedx-platform/blob/master/openedx/envs/common.py#L2078) to `True`

`Private Ref`: [BB-10465](https://tasks.opencraft.com/browse/BB-10465)

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
