### PR TITLE
[BB-10523] Add Reset to each node and change "Undo" text

### DIFF
--- a/branching_xblock/branching_xblock.py
+++ b/branching_xblock/branching_xblock.py
@@ -65,10 +65,10 @@ class BranchingXBlock(XBlock):
         help="Enable scoring for gradebook integration"
     )
 
-    enable_hints = Boolean(
+    enable_reset_activity = Boolean(
         default=False,
-        scope=Scope.settings,
-        help="Allow learners to reveal hints for each node"
+        scope=Scope.content,
+        help="Allow learners to reset the activity"
     )
 
     max_score = Float(
@@ -215,7 +215,7 @@ class BranchingXBlock(XBlock):
             "start_node_id": self.scenario_data.get("start_node_id"),
             "enable_undo": bool(self.enable_undo),
             "enable_scoring": bool(self.enable_scoring),
-            "enable_hints": bool(self.enable_hints),
+            "enable_reset_activity": bool(self.enable_reset_activity),
             "max_score":   self.max_score,
             "display_name": self.display_name,
             "authoring_help_html": authoring_help_html,
@@ -230,7 +230,7 @@ class BranchingXBlock(XBlock):
             "start_node_id":   self.scenario_data.get("start_node_id"),
             "enable_undo":     bool(self.enable_undo),
             "enable_scoring":  bool(self.enable_scoring),
-            "enable_hints":    bool(self.enable_hints),
+            "enable_reset_activity": bool(self.enable_reset_activity),
             "max_score":       self.max_score,
             "display_name":    self.display_name,
             "current_node":    self.get_current_node(),
@@ -292,6 +292,26 @@ class BranchingXBlock(XBlock):
             self.publish_grade()
 
         self.has_completed = False
+        return {"success": True, **self._get_state()}
+
+    @XBlock.json_handler
+    def reset_activity(self, data, suffix=''):
+        """
+        Reset learner state to the start node.
+        """
+        if not self.enable_reset_activity:
+            return {"success": False, "error": "Reset not allowed"}
+
+        self.current_node_id = None
+        self.history = []
+        self.has_completed = False
+
+        if self.enable_scoring:
+            self.score = 0.0
+            self.publish_grade()
+
+        self.start_node()
+        self.runtime.publish(self, "completion", {"completion": 0.0})
         return {"success": True, **self._get_state()}
 
     @XBlock.json_handler
@@ -370,7 +390,7 @@ class BranchingXBlock(XBlock):
         }
         self.enable_undo = bool(payload.get('enable_undo', self.enable_undo))
         self.enable_scoring = bool(payload.get('enable_scoring', self.enable_scoring))
-        self.enable_hints = bool(payload.get('enable_hints', self.enable_hints))
+        self.enable_reset_activity = bool(payload.get('enable_reset_activity', self.enable_reset_activity))
         self.max_score = float(payload.get('max_score', self.max_score))
         self.display_name = payload.get('display_name', self.display_name)
 

--- a/branching_xblock/static/css/branching_xblock.css
+++ b/branching_xblock/static/css/branching_xblock.css
@@ -197,6 +197,16 @@
     margin-left: 1em;
 }
 
+.reset-button {
+    border: 1px solid #4a5568;
+    border-radius: 4px;
+    padding: 0.6em 1.2em;
+    font-size: 1em;
+    cursor: pointer;
+    background: transparent;
+    color: #1f2a37;
+}
+
 .score-display {
     padding: 1em 1em;
     font-size: small;

--- a/branching_xblock/static/css/branching_xblock.css
+++ b/branching_xblock/static/css/branching_xblock.css
@@ -187,17 +187,14 @@
     text-decoration: none;
 }
 
-.undo-button {
-    border: none;
-    border-radius: 4px;
-    padding: 0.6em 1.2em;
-    font-size: 1em;
-    cursor: pointer;
-    background-image: none !important;
-    margin-left: 1em;
+.branching-scenario .action-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
 }
 
-.reset-button {
+.undo-button {
     border: 1px solid #4a5568;
     border-radius: 4px;
     padding: 0.6em 1.2em;
@@ -205,6 +202,28 @@
     cursor: pointer;
     background: transparent;
     color: #1f2a37;
+}
+
+.reset-button {
+    border: 1px solid #c2410c;
+    border-radius: 4px;
+    padding: 0.6em 1.2em;
+    font-size: 1em;
+    cursor: pointer;
+    background: transparent;
+    color: #c2410c;
+}
+
+.reset-button:hover,
+.reset-button:focus {
+    background: #fff7ed;
+    border-color: #9a3412;
+    color: #9a3412;
+}
+
+.reset-button:focus-visible {
+    outline: 2px solid #ea580c;
+    outline-offset: 2px;
 }
 
 .score-display {

--- a/branching_xblock/static/handlebars/settings-panel.handlebars
+++ b/branching_xblock/static/handlebars/settings-panel.handlebars
@@ -12,8 +12,8 @@
     Enable scoring
   </label>
   <label>
-    <input type="checkbox" name="enable_hints" {{#if enable_hints}}checked{{/if}}/>
-    Allow learners to reveal hints
+    <input type="checkbox" name="enable_reset_activity" {{#if enable_reset_activity}}checked{{/if}}/>
+    Enable reset activity
   </label>
   <label>
     Max Score:

--- a/branching_xblock/static/html/branching_xblock.html
+++ b/branching_xblock/static/html/branching_xblock.html
@@ -14,7 +14,10 @@
         <div class="choices" data-role="choices"></div>
 
         <button class="undo-button action-secondary btn-secondary" data-role="undo" style="display: none;">
-            <i class="fa fa-undo" aria-hidden="true"></i>&nbsp;Undo
+            Go Back
+        </button>
+        <button type="button" class="reset-button action-secondary btn-secondary" data-role="reset-activity" style="display: none;">
+            Reset
         </button>
 
         <div class="score-display" data-role="score" style="display: none;"></div>

--- a/branching_xblock/static/html/branching_xblock.html
+++ b/branching_xblock/static/html/branching_xblock.html
@@ -13,12 +13,14 @@
         </div>
         <div class="choices" data-role="choices"></div>
 
-        <button class="undo-button action-secondary btn-secondary" data-role="undo" style="display: none;">
-            Go Back
-        </button>
-        <button type="button" class="reset-button action-secondary btn-secondary" data-role="reset-activity" style="display: none;">
-            Reset
-        </button>
+        <div class="action-row">
+            <button class="undo-button action-secondary btn-secondary" data-role="undo" style="display: none;">
+                Go Back
+            </button>
+            <button type="button" class="reset-button action-secondary btn-secondary" data-role="reset-activity" style="display: none;">
+                Reset
+            </button>
+        </div>
 
         <div class="score-display" data-role="score" style="display: none;"></div>
     </div>

--- a/branching_xblock/static/js/src/branching_xblock.js
+++ b/branching_xblock/static/js/src/branching_xblock.js
@@ -133,8 +133,9 @@ function BranchingXBlock(runtime, element) {
         const $hintContainer = $el.find('[data-role="hint-container"]');
         const $hintDetails = $hintContainer.find('[data-role="hint-collapsible"]');
         const $hint = $hintDetails.find('[data-role="hint"]');
-        if (state.enable_hints && node && node.hint) {
-            $hint.html(`<strong>Hint:</strong> ${node.hint}`);
+        const hintText = (node && node.hint ? String(node.hint) : '').trim();
+        if (node && hintText) {
+            $hint.html(`<strong>Hint:</strong> ${hintText}`);
             $hintDetails.prop('hidden', false);
             setHintVisibility(isHintVisible);
         } else {
@@ -158,6 +159,9 @@ function BranchingXBlock(runtime, element) {
 
         const canUndo = state.enable_undo && state.history.length > 0;
         $el.find('.undo-button').toggle(canUndo);
+
+        const showReset = Boolean(state.enable_reset_activity);
+        $el.find('[data-role="reset-activity"]').toggle(showReset);
 
         const $score = $el.find('[data-role="score"]');
         const isLeaf = choices.length === 0;
@@ -196,6 +200,16 @@ function BranchingXBlock(runtime, element) {
     $el.on('click', '.undo-button', function() {
         $.ajax({
           url: runtime.handlerUrl(element, 'undo_choice'),
+          type: 'POST',
+          data: JSON.stringify({}),
+          contentType: 'application/json',
+          dataType: 'json'
+        }).done(refreshView);
+    });
+
+    $el.on('click', '[data-role="reset-activity"]', function() {
+        $.ajax({
+          url: runtime.handlerUrl(element, 'reset_activity'),
           type: 'POST',
           data: JSON.stringify({}),
           contentType: 'application/json',

--- a/branching_xblock/static/js/src/branching_xblock.js
+++ b/branching_xblock/static/js/src/branching_xblock.js
@@ -160,7 +160,10 @@ function BranchingXBlock(runtime, element) {
         const canUndo = state.enable_undo && state.history.length > 0;
         $el.find('.undo-button').toggle(canUndo);
 
-        const showReset = Boolean(state.enable_reset_activity);
+        const isAtStartNode = Boolean(
+            state.current_node && state.current_node.id === state.start_node_id
+        );
+        const showReset = Boolean(state.enable_reset_activity && !isAtStartNode);
         $el.find('[data-role="reset-activity"]').toggle(showReset);
 
         const $score = $el.find('[data-role="score"]');

--- a/branching_xblock/static/js/src/studio_editor.js
+++ b/branching_xblock/static/js/src/studio_editor.js
@@ -183,7 +183,7 @@ function BranchingStudioEditor(runtime, element, data) {
           nodes: [],
           enable_undo:    $settings.find('[name="enable_undo"]').is(':checked'),
           enable_scoring: $settings.find('[name="enable_scoring"]').is(':checked'),
-          enable_hints:   $settings.find('[name="enable_hints"]').is(':checked'),
+          enable_reset_activity: $settings.find('[name="enable_reset_activity"]').is(':checked'),
           max_score:      parseFloat($settings.find('[name="max_score"]').val()) || 0,
           display_name:   $settings.find('[name="display_name"]').val()?.trim() || ''
       };


### PR DESCRIPTION
## Description

This PR makes the following changes:

1. Replaces the "enable hint" settings with "enable reset" - This change was designed as part of the RenPy Designs but adding it here as per the request.
2. Rename "Undo" to "Go Back" - This was also included in the RenPy Designs but adding it here as requested.
3. Display "Reset" button on all nodes except the first one.


## Supporting Information

OpenCraft Internal Jira task: [BB-10523](https://tasks.opencraft.com/browse/BB-10523)


## Testing Instructions

1. Deploy this branch of the XBlock.
2. Set up a few nodes with hints and few without hints.
3. Verify that adding hints results in hints showing up in LMS, otherwise it doesn't.
4. Enable reset option in settings and confirm that "Reset" button shows up on all nodes except the first one.
5. Verify that clicking "Reset" clears the state and user returns to the first node.
